### PR TITLE
Fix cursor navigation and backspace functionality CodeTool

### DIFF
--- a/dev/index.html
+++ b/dev/index.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Code Plugin Test | EditorJS</title>
+  </head>
+  <body>
+    <div id="editorjs"></div>
+    <script src="https://cdn.jsdelivr.net/npm/@editorjs/editorjs@latest/dist/editor.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@editorjs/header@latest"></script>
+    <script src="../dist/code.umd.js"></script>
+    <script>
+      const editor = new EditorJS({
+        holder: 'editorjs',
+        data: {
+          time: 1700475383740,
+          blocks: [
+            {
+              id: 'aRMoZePSTD',
+              type: 'header',
+              data: { text: 'Welcome to Editor.js', level: 2 },
+            },
+            {
+              id: 'fcG8CCR5F8',
+              type: 'code',
+              data: { code: 'print("Namaste World")' },
+            },
+          ],
+        },
+        tools: {
+          code: CodeTool,
+          header: Header,
+        },
+      });
+    </script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@editorjs/code",
-  "version": "2.9.2",
+  "version": "2.9.3",
   "keywords": [
     "codex editor",
     "code",

--- a/src/index.ts
+++ b/src/index.ts
@@ -317,6 +317,19 @@ export default class CodeTool implements BlockTool {
         case 'Tab':
           this.tabHandler(event);
           break;
+        case 'Backspace':
+          if (textarea.value.length > 0) {
+            event.stopPropagation();
+          } else {
+            event.preventDefault();
+          }
+          break;
+        case 'ArrowUp':
+        case 'ArrowDown':
+        case 'ArrowLeft':
+        case 'ArrowRight':
+          event.stopPropagation();
+          break;
       }
     });
 


### PR DESCRIPTION
## Problem:
Users were unable to delete text with `backspace` and navigate through code.

## Solution:
Adjusted the `keydown` event handling in the **CodeTool** textarea by allowing default behavior for the backspace key while preventing caret navigation issues, ensuring normal text deletion and proper cursor movement across all browsers.

closes #67 