### PR TITLE
fix(paste): replace PasteEvent with HTMLPasteEvent to preserve innerHTML

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@editorjs/code",
-  "version": "2.9.3",
+  "version": "2.9.4",
   "keywords": [
     "codex editor",
     "code",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import './index.css';
 import { getLineStartPosition } from './utils/string';
 import { IconBrackets } from '@codexteam/icons';
-import type { API, BlockTool, BlockToolConstructorOptions, BlockToolData, HTMLPasteEvent, PasteConfig, SanitizerConfig, ToolboxConfig } from '@editorjs/editorjs';
+import type { API, BlockTool, BlockToolConstructorOptions, BlockToolData, PasteEvent, HTMLPasteEventDetail, PasteConfig, SanitizerConfig, ToolboxConfig } from '@editorjs/editorjs';
 
 /**
  * CodeTool for Editor.js
@@ -160,10 +160,15 @@ export default class CodeTool implements BlockTool {
    * onPaste callback fired from Editor`s core
    * @param event - event with pasted content
    */
-  public onPaste(event: HTMLPasteEvent): void {
-    this.data = {
-      code: event.detail.data.innerHTML,
-    };
+  public onPaste(event: PasteEvent): void {
+    switch (event.type) {
+      case 'tag': {
+        const element = (event.detail as HTMLPasteEventDetail).data;
+
+        this.handleHTMLPaste(element);
+        break;
+      }
+    }
   }
 
   /**
@@ -317,5 +322,15 @@ export default class CodeTool implements BlockTool {
     this.nodes.textarea = textarea;
 
     return wrapper;
+  }
+
+  /**
+   * Handles pasted HTML content
+   * @param element - pasted HTML element
+   */
+  private handleHTMLPaste(element: HTMLElement): void {
+    this.data = {
+      code: element.innerHTML,
+    };
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import './index.css';
 import { getLineStartPosition } from './utils/string';
 import { IconBrackets } from '@codexteam/icons';
-import type { API, BlockTool, BlockToolConstructorOptions, BlockToolData, PasteConfig, PasteEvent, SanitizerConfig, ToolboxConfig } from '@editorjs/editorjs';
+import type { API, BlockTool, BlockToolConstructorOptions, BlockToolData, HTMLPasteEvent, PasteConfig, SanitizerConfig, ToolboxConfig } from '@editorjs/editorjs';
 
 /**
  * CodeTool for Editor.js
@@ -160,16 +160,10 @@ export default class CodeTool implements BlockTool {
    * onPaste callback fired from Editor`s core
    * @param event - event with pasted content
    */
-  public onPaste(event: PasteEvent): void {
-    const detail = event.detail;
-
-    if ('data' in detail) {
-      const content = detail.data as string;
-
-      this.data = {
-        code: content || '',
-      };
-    }
+  public onPaste(event: HTMLPasteEvent): void {
+    this.data = {
+      code: event.detail.data.innerHTML,
+    };
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -325,7 +325,7 @@ export default class CodeTool implements BlockTool {
   }
 
   /**
-   * Handles pasted HTML content
+   * Extracts the code content from the pasted element's innerHTML and populates the tool's data.
    * @param element - pasted HTML element
    */
   private handleHTMLPaste(element: HTMLElement): void {


### PR DESCRIPTION
**Problem:**
Pasting HTML-embedded code into the editor causes incorrect behavior: the `HTMLPreElement` is rendered as a string instead of the actual code.

**Issue:**
https://github.com/codex-team/editor.js/issues/2923

**Solution:**
Replace the generic `PasteEvent` with the more specific `HTMLPasteEvent` to correctly access the `innerHTML` property.